### PR TITLE
Add network_id parameter

### DIFF
--- a/example/.terraform.lock.hcl
+++ b/example/.terraform.lock.hcl
@@ -2,10 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/dmacvicar/libvirt" {
-  version     = "0.6.3"
+  version     = "0.6.14"
   constraints = ">= 0.6.3"
   hashes = [
-    "h1:PeCMjwL6WqodhdQfUHElSjDk6uIcCILR1XbuLJEJ/j8=",
+    "h1:JyRYY5LmhQKvolpmwcfiWWlFJMMfvQKqP3PRWT0I2JU=",
+    "zh:0450e09888e0399722d6714467d5f0a61d2ab6505cd4c66423d58dd98404da80",
+    "zh:263c80ca9743bcc699983803b85cac19f833663478b644c2b3000a6f3e1b5070",
+    "zh:2a3eda5b0dc170afd4339910396e6087181dd0f37da0d83ee175fed2975a5a40",
+    "zh:363b8385d3340688fe58c67ea1e798d99892e25ac0a38f3e3fd615968b829e3e",
+    "zh:517efa2132c6ff6a849abea324916884a2d8e9361197209c56da99d1419542a3",
+    "zh:5f1424da9a9c9aef6b5583861750ed958fff4f1f85e17a493b58aff05b5a731b",
+    "zh:778bd0ea056ed7e918bcc3c05ad651504af86e6b53e6480daf20879e7d01e0a1",
+    "zh:8576f08eff1596d96072e6eb0c29febbbe316cc26537a949be76c71659bd3b63",
+    "zh:a1f5bbadad4f809d4b96a332bda1b48787d08a8bf3bf23b40e68138fbaa727fb",
+    "zh:b24e1f6f1bd09acdfb87f76f76ee7adfa1af1e0798c8c0aeb20d2a5bf67d8a33",
+    "zh:b6359aab7499b6fab819c867901b32426eb8661f2279e12c0c07cbeadce119e1",
+    "zh:ca357e2424a41058571f4b437a5e440395755461dcc1041cbbb41ea23c29eab5",
+    "zh:ec57e6e3ee701522d2cfd57a8ae307e76bff4f4a4af36c0e10d4189fa8dd554d",
+    "zh:f46534893933d5b11f32fb0d55044ba84f4e69147955d0454a208c494bbb0882",
   ]
 }
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -2,6 +2,8 @@ module "vm_example" {
   source = "../"
 
   vm = var.vm
+
+  network_id = var.network_id
 }
 
 output "name" {

--- a/example/tfvars/example.tfvars
+++ b/example/tfvars/example.tfvars
@@ -15,3 +15,5 @@ vm = {
   username               = "walter"
   vcpu                   = 1
 }
+
+network_id = "0d55a52d-fe3d-423a-8f59-e6380a1bfe31"

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -2,3 +2,34 @@ variable "vm" {
   type        = any
   description = "VM Spec"
 }
+
+/*
+
+Make sure the network_id you are providing via this variable provides Internet
+connectivity, otherwise, the machine will never be able to install packages required.
+
+The following error could happen if the machine is not able to install the
+package `qemu-guest-agent`
+
+╷
+│ Error: couldn't retrieve IP address of domain id: 450d26f1-96c3-4a8d-a8dc-46d1f7e1a57c. Please check following:
+│ 1) is the domain running proplerly?
+│ 2) has the network interface an IP address?
+│ 3) Networking issues on your libvirt setup?
+│  4) is DHCP enabled on this Domain's network?
+│ 5) if you use bridge network, the domain should have the pkg qemu-agent installed
+│ IMPORTANT: This error is not a terraform libvirt-provider error, but an error caused by your KVM/libvirt infrastructure configuration/setup
+│  timeout while waiting for state to become 'all-addresses-obtained' (last state: 'waiting-addresses', timeout: 5m0s)
+│
+│   with module.vm_example.libvirt_domain.vm[0],
+│   on ../main.tf line 1, in resource "libvirt_domain" "vm":
+│    1: resource "libvirt_domain" "vm" {
+│
+
+*/
+
+variable "network_id" {
+  description = "The corresponding network id that vms will use"
+  type        = string
+  default     = ""
+}

--- a/example/versions.tf
+++ b/example/versions.tf
@@ -4,8 +4,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     libvirt = {
-      source  = "dmacvicar/libvirt"
-      version = ">=0.6.3"
+      source = "dmacvicar/libvirt"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,10 @@ resource "libvirt_domain" "vm" {
   cloudinit = element(libvirt_cloudinit_disk.cloudinit.*.id, count.index)
 
   network_interface {
-    bridge         = var.vm.bridge_interface_name
+    network_id = var.network_id
+
+    bridge = var.network_id == "" ? var.vm.bridge_interface_name : ""
+
     wait_for_lease = true
     hostname       = format("${var.vm.name_prefix}%02d", count.index + 1)
   }

--- a/variables.tf
+++ b/variables.tf
@@ -35,3 +35,35 @@ variable "vm" {
     vcpu                   = 1
   }
 }
+
+
+/*
+
+Make sure the network_id you are providing via this variable provides Internet
+connectivity, otherwise, the machine will never be able to install packages required.
+
+The following error could happen if the machine is not able to install the
+package `qemu-guest-agent`
+
+╷
+│ Error: couldn't retrieve IP address of domain id: 450d26f1-96c3-4a8d-a8dc-46d1f7e1a57c. Please check following:
+│ 1) is the domain running proplerly?
+│ 2) has the network interface an IP address?
+│ 3) Networking issues on your libvirt setup?
+│  4) is DHCP enabled on this Domain's network?
+│ 5) if you use bridge network, the domain should have the pkg qemu-agent installed
+│ IMPORTANT: This error is not a terraform libvirt-provider error, but an error caused by your KVM/libvirt infrastructure configuration/setup
+│  timeout while waiting for state to become 'all-addresses-obtained' (last state: 'waiting-addresses', timeout: 5m0s)
+│
+│   with module.vm_example.libvirt_domain.vm[0],
+│   on ../main.tf line 1, in resource "libvirt_domain" "vm":
+│    1: resource "libvirt_domain" "vm" {
+│
+
+*/
+
+variable "network_id" {
+  description = "The corresponding network id that vms will use"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Add `network_id` parameter, this allow to deploy the vms on a libvirt network previously created via [libvirt_network](https://registry.terraform.io/providers/dmacvicar/libvirt/latest/docs/resources/network)